### PR TITLE
gtk: Create dialog picker for projects and settings.

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -66,14 +66,9 @@ You must have PyGObject and GTK installed.
 ```bash
 # must run from the src directory
 cd .../src
-python REgtk.py upstream DIS mytest --recon standard --mel hand --run weird --fuzzy fuzzy
+python REgtk.py
 ```
 NB
-* To work on the table of correspondences, save before clicking on batch
-upstream to update the results.
-* the specified 'experiment' (``mytest``) in the example above must already exist.
-* you can create such an experiment from the command line:
-```bash
-python REcli.py new-experiment DIS mytest2
-created new experiment
-```
+* The GTK application modifies the project directory directly. An
+  interface for sandboxing different input states and comparing the
+  inputs and outputs is planned!

--- a/src/howto.gtk
+++ b/src/howto.gtk
@@ -12,5 +12,4 @@ export DYLD_FALLBACK_LIBRARY_PATH="$BREW_PREFIX/lib${DYLD_FALLBACK_LIBRARY_PATH:
 pip install regex lxml
 pip install -r requirements.txt
 cd RE/src
-python REcli.py new-experiment DIS test
-python REgtk.py upstream DIS  test  --recon standard --mel hand --run run --fuzzy fuzzy
+python REgtk.py


### PR DESCRIPTION
This change creates a nice dialog picker for the projects and settings to use. This way, people don't have to mess with the hairy command line parser thing.

Also, in a push to rethink experiments, this change makes REGtk go back to modifying the projects directory directly.

Update the README and howto accordingly.

<img width="605" height="408" alt="Bildschirmfoto 2025-09-17 um 16 41 05" src="https://github.com/user-attachments/assets/2aa93749-9ca9-43e1-a934-3da23978e2e7" />